### PR TITLE
Add Domain Layer with UseCase, Repository Interface, and Model

### DIFF
--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,6 +1,9 @@
 plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.android)
+    alias(libs.plugins.hilt)
+    id("com.google.devtools.ksp")
+    id("kotlin-parcelize")
 }
 
 android {
@@ -33,6 +36,15 @@ android {
 }
 
 dependencies {
+
+    //Hilt
+    implementation(libs.hilt.android)
+    ksp(libs.hilt.compiler)
+    implementation(libs.androidx.hilt.navigation.compose)
+
+    //Paging
+    implementation(libs.androidx.paging.compose)
+    implementation(libs.androidx.paging.runtime)
 
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -37,19 +37,33 @@ android {
 
 dependencies {
 
-    //Hilt
+    // Hilt
     implementation(libs.hilt.android)
     ksp(libs.hilt.compiler)
     implementation(libs.androidx.hilt.navigation.compose)
 
-    //Paging
+    // Paging
     implementation(libs.androidx.paging.compose)
     implementation(libs.androidx.paging.runtime)
+    testImplementation(libs.androidx.paging.testing)
 
+    // Robolectric
+    testImplementation(libs.robolectric)
+
+    // AndroidX & Material
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.appcompat)
     implementation(libs.material)
+
+    // Coroutines
+    implementation(libs.kotlinx.coroutines.android)
+
+    // Tests
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
+
+    // Instrumentation tests
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }

--- a/domain/src/main/java/com/kev/domain/DomainModule.kt
+++ b/domain/src/main/java/com/kev/domain/DomainModule.kt
@@ -1,0 +1,18 @@
+package com.kev.domain
+
+import com.kev.domain.repository.ContactRepository
+import com.kev.domain.usecase.GetContactsListUseCase
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+class DomainModule {
+    @Singleton
+    @Provides
+    fun provideGetContactsListUseCase(contactRepository: ContactRepository): GetContactsListUseCase =
+        GetContactsListUseCase(contactRepository::fetchContacts)
+}

--- a/domain/src/main/java/com/kev/domain/repository/ContactRepository.kt
+++ b/domain/src/main/java/com/kev/domain/repository/ContactRepository.kt
@@ -1,0 +1,21 @@
+package com.kev.domain.repository
+
+import androidx.paging.PagingData
+import com.kev.domain.model.Contact
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Interface defining the repository methods for fetching real estate data.
+ * This interface abstracts the data layer and is used by use cases to interact
+ * with the data source(s) without knowing the details of the data retrieval.
+ */
+interface ContactRepository {
+
+    /**
+     * Fetches a list of all real estate.
+     *
+     * @return A [Flow] emitting a list of [Contact] containing the list of real estate.
+     */
+    suspend fun fetchContacts(): Flow<PagingData<Contact>>
+
+}

--- a/domain/src/main/java/com/kev/domain/usecase/GetContactsListUseCase.kt
+++ b/domain/src/main/java/com/kev/domain/usecase/GetContactsListUseCase.kt
@@ -1,0 +1,9 @@
+package com.kev.domain.usecase
+
+import androidx.paging.PagingData
+import com.kev.domain.model.Contact
+import kotlinx.coroutines.flow.Flow
+
+fun interface GetContactsListUseCase {
+    suspend operator fun invoke(): Flow<PagingData<Contact>>
+}

--- a/domain/src/test/java/com/kev/domain/GetContactsListUseCaseTest.kt
+++ b/domain/src/test/java/com/kev/domain/GetContactsListUseCaseTest.kt
@@ -1,0 +1,68 @@
+package com.kev.domain
+
+import androidx.paging.PagingData
+import androidx.paging.testing.asSnapshot
+import com.kev.domain.model.Contact
+import com.kev.domain.repository.ContactRepository
+import com.kev.domain.usecase.GetContactsListUseCase
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+
+class GetContactListUseCaseTest {
+    private val repository = mockk<ContactRepository>()
+    private lateinit var useCase: GetContactsListUseCase
+
+    @Before
+    fun setup() {
+        useCase = GetContactsListUseCase(repository::fetchContacts)
+    }
+
+    @Test
+    fun `invoke should return contacts from repository`() = runTest {
+        // Given
+        val dummyContacts = listOf(
+            Contact(
+                id = "1",
+                fullName = "John Doe",
+                username = "johndoe",
+                gender = "male",
+                email = "john@example.com",
+                phone = "123456789",
+                avatarUrl = "http://example.com/avatar.jpg",
+                city = "Paris",
+                country = "France",
+                age = 30,
+                registeredDate = "2020-01-01"
+            )
+        )
+        val dummyFlow = flowOf(PagingData.from(dummyContacts))
+        coEvery { repository.fetchContacts() } returns dummyFlow
+
+        // When
+        val resultFlow = useCase()
+
+        // Then
+        val snapshot = resultFlow.asSnapshot()
+        assertEquals(dummyContacts, snapshot)
+    }
+
+    @Test
+    fun `invoke should return empty list when repository has no contacts`() = runTest {
+        // Given
+        val dummyFlow = flowOf(PagingData.from(emptyList<Contact>()))
+        coEvery { repository.fetchContacts() } returns dummyFlow
+
+        // When
+        val resultFlow = useCase()
+
+        // Then
+        val snapshot = resultFlow.asSnapshot()
+        assertEquals(emptyList<Contact>(), snapshot)
+    }
+
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -53,6 +53,7 @@ retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = 
 retrofit-gson-converter = { group = "com.squareup.retrofit2", name = "converter-gson", version.ref = "retrofit" }
 androidx-paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.ref = "pagingRuntime" }
 androidx-paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "pagingCompose" }
+androidx-paging-testing = { group = "androidx.paging", name = "paging-testing", version.ref = "pagingRuntime" }
 androidx-room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 androidx-room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 androidx-room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }


### PR DESCRIPTION
This PR introduces the Domain layer to the project, including:

- Contact domain model, implementing Parcelable.

- ContactRepository interface to abstract data source interactions.

- GetContactsListUseCase as a functional use case for fetching contacts.

- DomainModule providing the use case via Hilt dependency injection.

- Unit tests for the use case using PagingData and mock repository.

- This setup separates the business logic from the data layer and UI, aligning with Clean Architecture principles.